### PR TITLE
Bug Fix: ExtendedFieldset $view property:

### DIFF
--- a/src/Filament/Components/ExtendedFieldset.php
+++ b/src/Filament/Components/ExtendedFieldset.php
@@ -9,7 +9,10 @@ class ExtendedFieldset extends Fieldset implements HasHeaderActions
 {
     use \Filament\Forms\Components\Concerns\HasHeaderActions;
 
-    protected string $view = 'visual-forms::livewire.extended-fieldset';
+    public function getView(): string
+    {
+        return 'visual-forms::livewire.extended-fieldset';
+    }
 
     public function getId(): ?string
     {


### PR DESCRIPTION
- Error: Property Coolsam\VisualForms\Filament\Components\ExtendedFieldset::$view (view-string) does not accept default value of type string.
- Error: Static property Coolsam\VisualForms\Filament\Resources\VisualFormResource\Widgets\FieldEditor::$view (view-string) does not accept default value of type string.